### PR TITLE
Add API jar generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,12 +69,22 @@ jar {
     }
 }
 
+task apiJar(type: Jar) {
+    from sourceSets.main.allSource
+    from sourceSets.main.output
+    include 'joshie/harvest/api/**/*'
+    classifier = 'api'
+}
+
+tasks.build.dependsOn apiJar
+
 publishing {
     tasks.publish.dependsOn 'build'
     publications {
         mavenJava(MavenPublication) {
             artifactId 'Harvest-Festival'
             artifact jar
+            artifact apiJar
         }
     }
     repositories {


### PR DESCRIPTION
Useful for those who wish to add support, but do not want to have the full mod in their workspace.

To use in gradle, append `:api` to the end of your `deobfCompile` line.
